### PR TITLE
remove errors?

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,7 @@ relativeURLs = true
 
 [outputs]
   home = [ "HTML", "RSS", "JSON" ]
+  section = [ "HTML", "RSS" ]
 
 [blackfriday]
    plainIDAnchors = true


### PR DESCRIPTION
Following a suggestion at:

https://discourse.gohugo.io/t/error-warning-for-missing-template-that-does-exist/15287/13

to try to remove this error:

WARN 2019/04/14 21:00:54 Found no layout for "home", language "en", output format "JSON": create a template below /layouts with one of these filenames: index.en.json.json, home.en.json.json, list.en.json.json, index.json.json, home.json.json, list.json.json, index.en.json, home.en.json, list.en.json, index.json, home.json, list.json, _default/index.en.json.json, _default/home.en.json.json, _default/list.en.json.json, _default/index.json.json, _default/home.json.json, _default/list.json.json, _default/index.en.json, _default/home.en.json, _default/list.en.json, _default/index.json, _default/home.json, _default/list.json
597

