### PR TITLE
WMEN - Florida Panthers #116

### DIFF
--- a/content/hockey/florida-panthers.md
+++ b/content/hockey/florida-panthers.md
@@ -1,0 +1,12 @@
+---
+title: Florida Panthers
+---
+The [Florida Panthers radio network](https://www.nhl.com/panthers/fans/panthersradionetwork)
+has stations in southern Florida on the Atlantic coast.
+
+Stations include:
+
+* WMEN 640 "Fox Sports 640" Royal Palm Beach, via N0JEP West Palm Beach
+* WQAM 560 "The Joe" Miami
+
+More information via the [NHL Florida Panthers](https://www.nhl.com/panthers/) site.

--- a/content/radio/am-broadcast/wmen.md
+++ b/content/radio/am-broadcast/wmen.md
@@ -2,8 +2,11 @@
 title: WMEN 640 Royal Palm Beach, FL
 weight: 640
 ---
-WMEN "The Hurricane" 640 broadcasts New York Yankees
+WMEN "Fox Sports 640" broadcasts New York Yankees
 baseball to a Florida audience. Listen via 
-[NO2CW] Hollywood.
+[N0JEP] West Palm Beach.
 
-[NO2CW]:http://qth.ddns.net:8073/?f=640.00amz9
+The station also carries Florida Panthers hockey
+on the Panthers Radio Network.
+
+[N0JEP]:http://n0jep.ddns.net/?f=640.00amz9

--- a/content/radio/grid/EL.md
+++ b/content/radio/grid/EL.md
@@ -3,8 +3,13 @@ title: EL - Florida, Gulf of Mexico
 ---
 
 * EL96ta [NO2CW](http://qth.ddns.net:8073/) Miami, FL
+* EL96us [N0JEP](http://n0jep.ddns.net/) West Palm Beach, FL
 
 Baseball
 
 * New York Yankees on WMEN 640, Royal Palm Beach, FL
 * Miami Marlins on WINZ 940
+
+Hockey
+
+* Florida Panthers on WMEN 640

--- a/content/radio/grid/EL.md
+++ b/content/radio/grid/EL.md
@@ -2,6 +2,7 @@
 title: EL - Florida, Gulf of Mexico
 ---
 
+* EL94 [KeyWest](http://keywest.twrmon.net:8073/) Key West, FL
 * EL96ta [NO2CW](http://qth.ddns.net:8073/) Miami, FL
 * EL96us [N0JEP](http://n0jep.ddns.net/) West Palm Beach, FL
 


### PR DESCRIPTION
Florida Panthers home team hockey in Florida.

Station has rebranded, previously 640 The Hurricane.

Closes #116