### PR TITLE
package.json (for Shippable, #205)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "commonplace",
+  "version": "0.0.1",
+  "description": "commonplace book, replacing a weblog.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/vielmetti/commonplace.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/vielmetti/commonplace/issues"
+  },
+  "homepage": "https://github.com/vielmetti/commonplace#readme"
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {},
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "markdownlint content"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #205 

Adds a minimal package.json with the markdownlint test.

This will need to be extended to identify all of the dependencies for markdownlint-cli and keep them up to date, but as a start the Shippable CI runs now pass.